### PR TITLE
Check `@mon_data` is defined

### DIFF
--- a/lib/ext_monitor.rb
+++ b/lib/ext_monitor.rb
@@ -68,11 +68,12 @@ module MonitorMixin
   # +MonitorMixin+.
   #
   def mon_synchronize(&b)
-    @mon_data.enter
+    mon_data = defined?(@mon_data) ? @mon_data : use_monitor_core
+    mon_data.enter
     begin
       yield
     ensure
-      @mon_data.exit
+      mon_data.exit
     end
   end
 


### PR DESCRIPTION
to avoid NoMethodError

I've got an error like below

```
        10: from /Users/ganmacs/.rbenv/versions/2.6.5/bin/bundle:23:in `<main>'
         9: from /Users/ganmacs/.rbenv/versions/2.6.5/bin/bundle:23:in `load'
         8: from /Users/ganmacs/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
         7: from /Users/ganmacs/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
         6: from /Users/ganmacs/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
         5: from /Users/ganmacs/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/cli.rb:26:in `start'
         4: from /Users/ganmacs/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/cli.rb:26:in `ensure in start'
         3: from /Users/ganmacs/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/shared_helpers.rb:144:in `print_major_deprecations!'
         2: from /Users/ganmacs/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/shared_helpers.rb:253:in `search_up'
         1: from /Users/ganmacs/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/bundler-2.1.4/lib/bundler/shared_helpers.rb:57:in `pwd'
/Users/ganmacs/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/ext_monitor-0.1.1/lib/ext_monitor.rb:71:in `mon_synchronize': undefined method `enter' for nil:NilClass (NoMethodError)

```